### PR TITLE
Add score and high score display

### DIFF
--- a/game.js
+++ b/game.js
@@ -142,10 +142,9 @@ class GameController {
     this.scoreElem.style.display = 'none';
     this.highScoreElem.style.display = 'none';
 
-    this.score      = 0;
-    this.highScore  = parseInt(localStorage.getItem('highScore')) || 0;
-    this.highScorer = localStorage.getItem('highScorer') || '';
-    this.playerName = localStorage.getItem('playerName') || '';
+    this.score          = 0;
+    this.highScore      = parseInt(localStorage.getItem('highScore')) || 0;
+    this.highScoreDate  = localStorage.getItem('highScoreDate') || '';
     this._updateScores();
 
     this.imagesData = [
@@ -216,8 +215,8 @@ class GameController {
     if (this.scoreElem)
       this.scoreElem.textContent = `Score: ${this.score}`;
     if (this.highScoreElem) {
-      const by = this.highScorer ? ` (${this.highScorer})` : '';
-      this.highScoreElem.textContent = `High Score: ${this.highScore}${by}`;
+      const when = this.highScoreDate ? ` (${this.highScoreDate})` : '';
+      this.highScoreElem.textContent = `High Score: ${this.highScore}${when}`;
     }
   }
 
@@ -289,11 +288,6 @@ _handleMouseMove(e) {
       if (!this.isManual) {
         this.isManual = true;
         this.score = 0;
-        if (!this.playerName) {
-          const name = prompt('Enter your name:', '') || 'Player';
-          this.playerName = name.trim();
-          localStorage.setItem('playerName', this.playerName);
-        }
         this.scoreElem.style.display = 'block';
         this.highScoreElem.style.display = 'block';
         this._updateScores();
@@ -379,10 +373,10 @@ _handleMouseMove(e) {
       if (this.isManual) {
         this.score++;
         if (this.score > this.highScore) {
-          this.highScore  = this.score;
-          this.highScorer = this.playerName;
+          this.highScore     = this.score;
+          this.highScoreDate = new Date().toLocaleDateString();
           localStorage.setItem('highScore', this.highScore);
-          localStorage.setItem('highScorer', this.highScorer);
+          localStorage.setItem('highScoreDate', this.highScoreDate);
         }
       }
       this._spawnTarget();
@@ -394,10 +388,10 @@ _handleMouseMove(e) {
   _die() {
     cancelAnimationFrame(this.rafId);
     if (this.isManual && this.score > this.highScore) {
-      this.highScore  = this.score;
-      this.highScorer = this.playerName;
+      this.highScore     = this.score;
+      this.highScoreDate = new Date().toLocaleDateString();
       localStorage.setItem('highScore', this.highScore);
-      localStorage.setItem('highScorer', this.highScorer);
+      localStorage.setItem('highScoreDate', this.highScoreDate);
     }
     if (this.isManual) this._updateScores();
     let flashes = 0;

--- a/game.js
+++ b/game.js
@@ -134,7 +134,13 @@ class GameController {
     this.board          = new Board('game-canvas', this.CELL);
     this.spotifyEmbed   = document.getElementById('spotify-embed');
     this.embedContainer = document.getElementById('spotify-embed-container');
-    this.infobox = document.getElementById('info-box');
+      this.infobox = document.getElementById('info-box');
+
+      this.scoreElem     = document.getElementById('score');
+      this.highScoreElem = document.getElementById('high-score');
+      this.score     = 0;
+      this.highScore = parseInt(localStorage.getItem('highScore')) || 0;
+      this._updateScores();
 
     this.imagesData = [
       { src: 'assets/photo1.jpg', title: 'Verbathim (Album)', artist: 'Nemahsis',
@@ -198,6 +204,13 @@ class GameController {
     };
 
     this._preload().then(() => this.start());
+  }
+
+  _updateScores() {
+    if (this.scoreElem)
+      this.scoreElem.textContent = `Score: ${this.score}`;
+    if (this.highScoreElem)
+      this.highScoreElem.textContent = `High Score: ${this.highScore}`;
   }
 
   _preload() {
@@ -294,6 +307,9 @@ _handleMouseMove(e) {
   start() {
     if (this.rafId) cancelAnimationFrame(this.rafId);
 
+    this.score = 0;
+    this._updateScores();
+
     // compute interval from current speedup (bumped only in _die)
     this.interval = Math.max(this.MIN_SPEED, this.SPEED_BASE / this.speedup);
 
@@ -336,15 +352,27 @@ _handleMouseMove(e) {
 
     const ate = nextPos.x === this.target.x && nextPos.y === this.target.y;
     this.snake.growOrMove(nextPos, ate ? this.target.metaIndex : null);
-    if (ate) {this.speedup += 0.1; // Increment speedup factor
-              this.interval = Math.max(this.MIN_SPEED, this.SPEED_BASE / this.speedup);
-              this._spawnTarget();
-             }
+    if (ate) {
+      this.speedup += 0.1; // Increment speedup factor
+      this.interval = Math.max(this.MIN_SPEED, this.SPEED_BASE / this.speedup);
+      this.score++;
+      if (this.score > this.highScore) {
+        this.highScore = this.score;
+        localStorage.setItem('highScore', this.highScore);
+      }
+      this._spawnTarget();
+      this._updateScores();
+    }
     this.draw();
   }
 
   _die() {
     cancelAnimationFrame(this.rafId);
+    if (this.score > this.highScore) {
+      this.highScore = this.score;
+      localStorage.setItem('highScore', this.highScore);
+    }
+    this._updateScores();
     let flashes = 0;
 
     const flash = () => {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
 
   <!-- Game Container -->
   <div class="game-container">
+    <div id="score" class="score-label">Score: 0</div>
+    <div id="high-score" class="score-label">High Score: 0</div>
     <canvas id="game-canvas" width="800" height="450"></canvas>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -40,6 +40,22 @@ canvas {
   display: block;
 }
 
+.score-label {
+  position: absolute;
+  top: -24px;
+  font-weight: bold;
+  color: var(--font-color-dark);
+}
+
+#score {
+  left: 0;
+}
+
+#high-score {
+  right: 0;
+  text-align: right;
+}
+
 .info-box {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
## Summary
- display score and high score above the game board
- track score and persist high score with local storage

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68543f4fc9c4832faa53696e856f6de6