### PR TITLE
Improve game loop and cursor behavior

### DIFF
--- a/game.js
+++ b/game.js
@@ -78,7 +78,6 @@ class Snake {
     }
 
     const candidates = this._getCandidates(head, target);
-    console.log('    [move] head @', head, '→ candidates:', candidates);
     return candidates.length ? candidates[0] : null;
   }
 
@@ -188,12 +187,13 @@ class GameController {
     ];
     this.loadedImages = [];
 
-    this.snake     = null;
-    this.target    = null;
-    this.manualDir = null;
-    this.isManual  = false;
-    this.rafId     = null;
-    this.lastTime  = 0;
+    this.snake       = null;
+    this.target      = null;
+    this.manualDir   = null;
+    this.isManual    = false;
+    this.cursorActive = true; // disable cursor updates when playing
+    this.rafId       = null;
+    this.lastTime    = 0;
 
     this._bindEvents();
 
@@ -255,6 +255,11 @@ class GameController {
   }
 
 _handleMouseMove(e) {
+    if (!this.cursorActive) {
+        this.cursorActive = true;
+        return;
+    }
+
     const pos = this._getEventPos(e);
     const { cellSize } = this.board;
 
@@ -270,11 +275,9 @@ _handleMouseMove(e) {
         const md = this.imagesData[this.target.metaIndex];
         /*this.infoBox.textContent = `${md.title} — ${md.artist}`;*/
         this.board.canvas.style.cursor = 'pointer'; // Show pointer cursor
-        console.log('Cursor set to pointer over target'); // Debugging log
     } else {
         /*this.infoBox.textContent = '';*/
         this.board.canvas.style.cursor = 'default'; // Reset to default cursor
-        console.log('Cursor reset to default'); // Debugging log
     }
 }
 
@@ -289,6 +292,8 @@ _handleMouseMove(e) {
     if (map[e.key]) {
       if (!this.isManual) {
         this.isManual = true;
+        this.cursorActive = false;
+        this.board.canvas.style.cursor = 'default';
         this.score = 0;
         this.scoreElem.style.display = 'block';
         this.highScoreElem.style.display = 'block';
@@ -334,12 +339,9 @@ _handleMouseMove(e) {
     this.snake = new Snake(this.loadedImages, this.board);
     this.snake.init();
     this._spawnTarget();
+    this.cursorActive = true;
 
-    console.log('🏁 New round', {
-      head:    this.snake.positions[0],
-      target:  this.target,
-      speedup: this.speedup
-    });
+    // Round initialization complete
 
     this.lastTime = performance.now();
     this.isManual = false;
@@ -389,6 +391,8 @@ _handleMouseMove(e) {
 
   _die() {
     cancelAnimationFrame(this.rafId);
+    this.cursorActive = true;
+    this.board.canvas.style.cursor = 'default';
     if (this.isManual && this.score > this.highScore) {
       this.highScore     = this.score;
       this.highScoreDate = new Date().toLocaleDateString();


### PR DESCRIPTION
## Summary
- remove debug logging that caused slowdowns
- stop cursor updates during gameplay until the player moves their mouse again

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686541acb000832f835aeed3db966a6e