### PR TITLE
Fix more page images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/game.js
+++ b/game.js
@@ -146,45 +146,9 @@ class GameController {
     this.highScoreDate  = localStorage.getItem('highScoreDate') || '';
     this._updateScores();
 
-    this.imagesData = [
-      { src: 'assets/photo1.jpg', title: 'Verbathim (Album)', artist: 'Nemahsis',
-        spotifyUrl: 'https://open.spotify.com/track/2lmT9NiqohWoRf9yAxt4Ru?si=7291e441baaa452a' },
-      { src: 'assets/photo2.jpg', title: 'TV Show', artist: 'Katie Gregson-MacLeod',
-        spotifyUrl: 'https://open.spotify.com/track/0hQZyBWcYejAzb9WYM96pr?si=866aa6756cb24293' },
-       { src: 'assets/photo3.jpg', title: 'We Need To Talk', artist: 'Matt Maltese',
-        spotifyUrl: 'https://open.spotify.com/track/1gqMcDslzFtgOsAZDY58JX?si=f1e735a57f8e4076' },
-      { src: 'assets/photo4.jpg', title: 'Alone At The Party', artist: 'Sam Tompkins',
-        spotifyUrl: 'https://open.spotify.com/track/0YO7moiEboCUBDFf0hefSk?si=6abe803a16734b2e' },
-       { src: 'assets/photo5.jpg', title: 'Dollar Signs', artist: 'Nemahsis',
-        spotifyUrl: 'https://open.spotify.com/track/6YyEuMnthCvLOZCGEbksAF?si=ea15d86f0f7d416d' },
-      { src: 'assets/photo6.jpg', title: 'Coming Closer', artist: 'Duckwrth',
-        spotifyUrl: 'https://open.spotify.com/track/238p3EKRYESqsZdgE5DCDR?si=7f4332128f954948' },
-       { src: 'assets/photo7.jpg', title: 'This Is The Place', artist: 'Tom Grennan',
-        spotifyUrl: 'https://open.spotify.com/track/0UtoTf0kuz8x6Zfy59r8hp?si=9f2dc0ed23c54266' },
-      { src: 'assets/photo8.jpg', title: 'Skin', artist: 'Joy Crookes',
-        spotifyUrl: 'https://open.spotify.com/track/7k8b5u5fisGTDNahrJK6dw?si=2a87e548bd1c45ef' },
-       { src: 'assets/photo9.jpg', title: 'Paradise', artist: 'Griff',
-        spotifyUrl: 'https://open.spotify.com/track/7nfaD0trhQiStQ8DOQRC0h?si=9e7715a383e14fca' },
-          { src: 'assets/photo10.jpg', title: 'LMLY', artist: 'Jackson Wang',
-        spotifyUrl: 'https://open.spotify.com/track/3kPoV6L9vXpbxoM4Ux0KnX?si=6891a359c7fb4f50' },
-      { src: 'assets/photo11.jpg', title: '54321', artist: 'April',
-        spotifyUrl: 'https://open.spotify.com/track/6Vn5hk8NQIkzGsdkx5nF4q?si=42dbda986fb842fe' },
-       { src: 'assets/photo12.jpg', title: 'Boy Clothes', artist: 'Nxdia',
-        spotifyUrl: 'https://open.spotify.com/track/7nuCxvFvVT5YEAjSDd6Glr?si=a241207fac3348d8' },
-      { src: 'assets/photo13.jpg', title: 'Options (feat. Lil Baby)', artist: 'Jordan Adetunji',
-        spotifyUrl: 'https://open.spotify.com/track/0aQD4RI0U4pHWzNzQWTq9r?si=e5080b16576548f3' },
-       { src: 'assets/photo14.jpg', title: '305 (feat. Bryson Tiller)', artist: 'Jordan Adetunji',
-        spotifyUrl: 'https://open.spotify.com/track/494f07w2ArJNlkwnWWZViK?si=a3ff4f4b26ce4a53' },
-       { src: 'assets/photo15.jpg', title: 'Stick Of Gum', artist: 'Nemahsis',
-        spotifyUrl: 'https://open.spotify.com/track/7DvOMvKBZESff6Etf0v9MY?si=c31005880f374552' },
-         { src: 'assets/photo16.jpg', title: 'congrats! u did it!', artist: 'flowerovlove',
-        spotifyUrl: 'https://open.spotify.com/track/5bp8CvtJ8pbh2OK2HSfTwE?si=6895384a7d2343b5' },
-       { src: 'assets/photo17.jpg', title: 'Appetite', artist: 'Arthur Hill',
-        spotifyUrl: 'https://open.spotify.com/track/0q5zMDVszIVZb7kPi2XiOj?si=34033487b3344e8a' },
-       { src: 'assets/photo18.jpg', title: 'Body On Me', artist: 'Nxdia',
-        spotifyUrl: 'https://open.spotify.com/track/6MglZeuPDQwHzZTxrRZfCW?si=11e2487a15304c89' },
-      /* …etc… */
-    ];
+    // Song metadata is defined in images-data.js so it can be reused on other pages
+    this.imagesData = (window.imagesData || []).slice();
+    this._shuffle(this.imagesData);
     this.loadedImages = [];
 
     this.snake       = null;
@@ -432,6 +396,14 @@ _handleMouseMove(e) {
     };
 
     flash();
+  }
+
+  _shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
   }
 
   draw() {

--- a/images-data.js
+++ b/images-data.js
@@ -1,0 +1,20 @@
+window.imagesData = [
+  { src: 'assets/photo1.jpg', title: 'Verbathim (Album)', artist: 'Nemahsis', spotifyUrl: 'https://open.spotify.com/track/2lmT9NiqohWoRf9yAxt4Ru?si=7291e441baaa452a' },
+  { src: 'assets/photo2.jpg', title: 'TV Show', artist: 'Katie Gregson-MacLeod', spotifyUrl: 'https://open.spotify.com/track/0hQZyBWcYejAzb9WYM96pr?si=866aa6756cb24293' },
+  { src: 'assets/photo3.jpg', title: 'We Need To Talk', artist: 'Matt Maltese', spotifyUrl: 'https://open.spotify.com/track/1gqMcDslzFtgOsAZDY58JX?si=f1e735a57f8e4076' },
+  { src: 'assets/photo4.jpg', title: 'Alone At The Party', artist: 'Sam Tompkins', spotifyUrl: 'https://open.spotify.com/track/0YO7moiEboCUBDFf0hefSk?si=6abe803a16734b2e' },
+  { src: 'assets/photo5.jpg', title: 'Dollar Signs', artist: 'Nemahsis', spotifyUrl: 'https://open.spotify.com/track/6YyEuMnthCvLOZCGEbksAF?si=ea15d86f0f7d416d' },
+  { src: 'assets/photo6.jpg', title: 'Coming Closer', artist: 'Duckwrth', spotifyUrl: 'https://open.spotify.com/track/238p3EKRYESqsZdgE5DCDR?si=7f4332128f954948' },
+  { src: 'assets/photo7.jpg', title: 'This Is The Place', artist: 'Tom Grennan', spotifyUrl: 'https://open.spotify.com/track/0UtoTf0kuz8x6Zfy59r8hp?si=9f2dc0ed23c54266' },
+  { src: 'assets/photo8.jpg', title: 'Skin', artist: 'Joy Crookes', spotifyUrl: 'https://open.spotify.com/track/7k8b5u5fisGTDNahrJK6dw?si=2a87e548bd1c45ef' },
+  { src: 'assets/photo9.jpg', title: 'Paradise', artist: 'Griff', spotifyUrl: 'https://open.spotify.com/track/7nfaD0trhQiStQ8DOQRC0h?si=9e7715a383e14fca' },
+  { src: 'assets/photo10.jpg', title: 'LMLY', artist: 'Jackson Wang', spotifyUrl: 'https://open.spotify.com/track/3kPoV6L9vXpbxoM4Ux0KnX?si=6891a359c7fb4f50' },
+  { src: 'assets/photo11.jpg', title: '54321', artist: 'April', spotifyUrl: 'https://open.spotify.com/track/6Vn5hk8NQIkzGsdkx5nF4q?si=42dbda986fb842fe' },
+  { src: 'assets/photo12.jpg', title: 'Boy Clothes', artist: 'Nxdia', spotifyUrl: 'https://open.spotify.com/track/7nuCxvFvVT5YEAjSDd6Glr?si=a241207fac3348d8' },
+  { src: 'assets/photo13.jpg', title: 'Options (feat. Lil Baby)', artist: 'Jordan Adetunji', spotifyUrl: 'https://open.spotify.com/track/0aQD4RI0U4pHWzNzQWTq9r?si=e5080b16576548f3' },
+  { src: 'assets/photo14.jpg', title: '305 (feat. Bryson Tiller)', artist: 'Jordan Adetunji', spotifyUrl: 'https://open.spotify.com/track/494f07w2ArJNlkwnWWZViK?si=a3ff4f4b26ce4a53' },
+  { src: 'assets/photo15.jpg', title: 'Stick Of Gum', artist: 'Nemahsis', spotifyUrl: 'https://open.spotify.com/track/7DvOMvKBZESff6Etf0v9MY?si=c31005880f374552' },
+  { src: 'assets/photo16.jpg', title: 'congrats! u did it!', artist: 'flowerovlove', spotifyUrl: 'https://open.spotify.com/track/5bp8CvtJ8pbh2OK2HSfTwE?si=6895384a7d2343b5' },
+  { src: 'assets/photo17.jpg', title: 'Appetite', artist: 'Arthur Hill', spotifyUrl: 'https://open.spotify.com/track/0q5zMDVszIVZb7kPi2XiOj?si=34033487b3344e8a' },
+  { src: 'assets/photo18.jpg', title: 'Body On Me', artist: 'Nxdia', spotifyUrl: 'https://open.spotify.com/track/6MglZeuPDQwHzZTxrRZfCW?si=11e2487a15304c89' }
+];

--- a/index.html
+++ b/index.html
@@ -35,11 +35,12 @@
     <ul class="contacts">
       <li><a href="mailto:info@dannycasio.com" aria-label="Email Danny Casio">Email</a></li>
       <li><a href="https://instagram.com/dannycasio_/" target="_blank" aria-label="Visit Danny Casio's Instagram">Instagram</a></li>
-      <li><a href="https://open.spotify.com/playlist/37i9dQZF1EFCSLSz1lSDiP?si=45a9c9f28bfe43e8" target="_blank" aria-label="Listen to Danny Casio on Spotify">Spotify</a></li>
+      <li><a href="more.html" aria-label="View more info">More</a></li>
     </ul>
   </footer>
 
-  <!-- JavaScript File -->
+  <!-- Shared song metadata and game script -->
+  <script src="images-data.js"></script>
   <script src="game.js" defer></script>
 </body>
 </html>

--- a/more.html
+++ b/more.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>More - Danny Casio</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="index.html" class="back-button" aria-label="Back to home">Back</a>
+  <div id="songs" class="songs-container"></div>
+  <script src="images-data.js"></script>
+  <script src="more.js" defer></script>
+</body>
+</html>

--- a/more.js
+++ b/more.js
@@ -1,0 +1,28 @@
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function loadSongs() {
+  const songs = shuffle((window.imagesData || []).slice());
+  const container = document.getElementById('songs');
+  songs.forEach(song => {
+    const link = document.createElement('a');
+    link.href = song.spotifyUrl;
+    link.target = '_blank';
+    link.className = 'song-item';
+
+    const img = document.createElement('img');
+    img.src = song.src;
+    img.alt = '';
+
+    link.appendChild(img);
+    container.appendChild(link);
+  });
+  console.log(`Loaded ${songs.length} songs`);
+}
+
+document.addEventListener('DOMContentLoaded', loadSongs);

--- a/public/data/songs.json
+++ b/public/data/songs.json
@@ -1,0 +1,14 @@
+[
+  {
+    "artwork": "https://i.scdn.co/image/ab67616d0000b2732aa9537d450a0bf18958a51d",
+    "title": "Paradise",
+    "artist": "Griff",
+    "link": "https://open.spotify.com/track/7nfaD0trhQiStQ8DOQRC0h"
+  },
+  {
+    "artwork": "https://i.scdn.co/image/ab67616d0000b27335366cb5fbf4211e87e3b18",
+    "title": "Skin",
+    "artist": "Joy Crookes",
+    "link": "https://open.spotify.com/track/7k8b5u5fisGTDNahrJK6dw"
+  }
+]

--- a/style.css
+++ b/style.css
@@ -129,3 +129,27 @@ footer {
 }
 
 /* Remove unused or commented-out code for clarity */
+
+/* Styles for the More page */
+.songs-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--gap-large);
+  width: var(--container-width);
+  max-width: var(--container-max-width);
+  margin: var(--gap-large) auto;
+}
+
+.song-item img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--border-radius);
+  display: block;
+}
+
+.back-button {
+  margin: var(--gap-large) 0;
+  text-decoration: none;
+  color: var(--font-color-dark);
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- centralize song metadata in `images-data.js`
- load that metadata on the More page instead of using `songs.json`
- update game script to read from the shared data file
- randomize the image order on each page load

## Testing
- no tests present

------
https://chatgpt.com/codex/tasks/task_e_68655afdfca4832f850c47bd9cbb55b5