### PR TITLE
Add Next.js drop-portal

### DIFF
--- a/drop-portal/.env.local.example
+++ b/drop-portal/.env.local.example
@@ -1,0 +1,3 @@
+NEXTCLOUD_BASE_URL=https://nextcloud.example.com
+NEXTCLOUD_USER=username
+NEXTCLOUD_PASSWORD=password

--- a/drop-portal/.gitignore
+++ b/drop-portal/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/drop-portal/next.config.js
+++ b/drop-portal/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/drop-portal/package.json
+++ b/drop-portal/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "drop-portal",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "axios": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "latest",
+    "autoprefixer": "latest",
+    "postcss": "latest"
+  }
+}

--- a/drop-portal/pages/_app.js
+++ b/drop-portal/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/drop-portal/pages/api/drop/v1/files/[id].js
+++ b/drop-portal/pages/api/drop/v1/files/[id].js
@@ -1,0 +1,49 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const {
+    NEXTCLOUD_BASE_URL,
+    NEXTCLOUD_USER,
+    NEXTCLOUD_PASSWORD,
+  } = process.env;
+
+  const { id } = req.query;
+
+  if (!NEXTCLOUD_BASE_URL || !NEXTCLOUD_USER || !NEXTCLOUD_PASSWORD) {
+    res.status(500).json({ error: 'Nextcloud configuration missing' });
+    return;
+  }
+
+  try {
+    const api = axios.create({
+      baseURL: NEXTCLOUD_BASE_URL,
+      auth: {
+        username: NEXTCLOUD_USER,
+        password: NEXTCLOUD_PASSWORD,
+      },
+      headers: { 'OCS-APIRequest': 'true' },
+    });
+
+    const shareRes = await api.get(`/ocs/v2.php/apps/files_sharing/api/v1/shares/${id}?format=json`);
+    const data = shareRes.data?.ocs?.data;
+    if (!data) {
+      res.status(404).json({ error: 'Share not found' });
+      return;
+    }
+
+    const fileInfo = Array.isArray(data) ? data[0] : data;
+    const downloadUrl = `${NEXTCLOUD_BASE_URL}/public-files/${fileInfo.token}`;
+
+    res.status(200).json({
+      token: fileInfo.token,
+      name: fileInfo.name,
+      mime: fileInfo.mimetype,
+      description: fileInfo.note || '',
+      downloadUrl,
+      auth: { username: NEXTCLOUD_USER, password: NEXTCLOUD_PASSWORD },
+    });
+  } catch (err) {
+    const status = err.response?.status || 500;
+    res.status(status).json({ error: 'Unable to fetch share information' });
+  }
+}

--- a/drop-portal/pages/drop/[token]/download.js
+++ b/drop-portal/pages/drop/[token]/download.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+export default function Download() {
+  return null;
+}
+
+export async function getServerSideProps({ params, req, res }) {
+  const { token } = params;
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${req.headers.host}`;
+    const { data } = await axios.get(`${baseUrl}/api/drop/v1/files/${token}`);
+    const fileRes = await axios.get(data.downloadUrl, {
+      responseType: 'stream',
+      headers: {
+        Accept: 'application/octet-stream',
+      },
+      auth: data.auth,
+    });
+
+    res.setHeader('Content-Disposition', `attachment; filename="${data.name}"`);
+    fileRes.data.pipe(res);
+    res.statusCode = 200;
+    res.on('close', () => fileRes.data.destroy());
+    return { props: {} };
+  } catch (err) {
+    res.statusCode = err.response?.status || 500;
+    res.end(err.response?.data || 'Error downloading');
+    return { props: {} };
+  }
+}

--- a/drop-portal/pages/drop/[token]/index.js
+++ b/drop-portal/pages/drop/[token]/index.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import Link from 'next/link';
+
+export async function getServerSideProps({ params, req }) {
+  const { token } = params;
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${req.headers.host}`;
+    const { data } = await axios.get(`${baseUrl}/api/drop/v1/files/${token}`);
+    return { props: { meta: data } };
+  } catch (err) {
+    return { props: { error: err.response?.data?.error || 'Failed to fetch metadata' } };
+  }
+}
+
+export default function DropPage({ meta, error }) {
+  if (error) {
+    return <div className="p-4 text-red-600">{error}</div>;
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">{meta.name}</h1>
+      {meta.description && <p className="mb-2">{meta.description}</p>}
+      <Link href={`/drop/${meta.token}/download`} className="bg-blue-500 text-white px-4 py-2 rounded">
+        Download
+      </Link>
+      {meta.mime?.startsWith('audio/') && (
+        <div className="mt-4">
+          <audio controls src={`/drop/${meta.token}/stream`} className="w-full" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/drop-portal/pages/drop/[token]/stream.js
+++ b/drop-portal/pages/drop/[token]/stream.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+export default function Stream() {
+  return null;
+}
+
+export async function getServerSideProps({ params, req, res }) {
+  const { token } = params;
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${req.headers.host}`;
+    const { data } = await axios.get(`${baseUrl}/api/drop/v1/files/${token}`);
+    const range = req.headers.range || '';
+    const fileRes = await axios.get(data.downloadUrl, {
+      responseType: 'stream',
+      headers: {
+        Range: range,
+      },
+      auth: data.auth,
+    });
+
+    res.statusCode = fileRes.status;
+    res.setHeader('Accept-Ranges', 'bytes');
+    for (const [key, value] of Object.entries(fileRes.headers)) {
+      if (typeof value !== 'undefined') {
+        res.setHeader(key, value);
+      }
+    }
+    fileRes.data.pipe(res);
+    res.on('close', () => fileRes.data.destroy());
+    return { props: {} };
+  } catch (err) {
+    res.statusCode = err.response?.status || 500;
+    res.end('Error streaming');
+    return { props: {} };
+  }
+}

--- a/drop-portal/pages/index.js
+++ b/drop-portal/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-2xl font-bold">Drop Portal</h1>
+    </div>
+  );
+}

--- a/drop-portal/postcss.config.js
+++ b/drop-portal/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/drop-portal/styles/globals.css
+++ b/drop-portal/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/drop-portal/tailwind.config.js
+++ b/drop-portal/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add `drop-portal` Next.js project for file sharing
- implement API route calling Nextcloud
- landing page with download and streaming features
- streaming and download endpoints proxy Nextcloud
- include Tailwind CSS and example env file

## Testing
- `node -v`
- *No further tests run due to missing package installation.*

------
https://chatgpt.com/codex/tasks/task_e_6867ae873998832fb048d38d0b9171fc