### PR TITLE
Add Nextcloud drop page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Artwork Snake
 
 A small snake game that uses images for the snake body. Open `index.html` in your browser to play.
+
+## Testing the drop page
+
+- Start a local server: `npx serve public`
+- Visit `http://localhost:5000/drop/<token>` replacing `<token>` with a real Nextcloud share token.
+- Run `curl -I http://localhost:5000/drop/<token>` to confirm the redirect to `drop.html` works.
+- In browser DevTools, check the Network tab and console for errors to verify the iframe loads the Nextcloud UI.

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/drop/*    /drop.html    200

--- a/public/drop.html
+++ b/public/drop.html
@@ -1,0 +1,34 @@
+<!--
+  To test locally:
+  1. Run: npx serve public
+  2. Visit: http://localhost:5000/drop/<shareToken>
+  3. Replace <shareToken> with a real Nextcloud token.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <base href="/">
+  <title>Drop - Danny Casio</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Danny Casio Drop</h1>
+  </header>
+  <iframe id="drop-frame" style="width:100%;height:80vh;border:none;"></iframe>
+  <footer>
+    <p>&copy; Danny Casio</p>
+  </footer>
+  <script>
+    const iframe = document.getElementById('drop-frame');
+    const m = location.pathname.match(/^\/drop\/([^\/]+)$/);
+    if (!m) {
+      iframe.srcdoc = '<p style="padding:1rem">No share token provided.</p>';
+    } else {
+      iframe.src = 'https://transfer.dannycasio.com/s/' + m[1];
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a drop page that can embed a Nextcloud share via token
- rewrite `/drop/*` URLs to `drop.html`
- document how to test the new drop page

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6867d5794c28832f9d848af44b3e5fe9