### PR TITLE
Remove main background on drop page

### DIFF
--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -14,7 +14,7 @@
         "Helvetica Neue", Arial, sans-serif;
       color: #000;
     }
-    main { max-width:800px; margin:4rem auto 2rem; background:#fff; padding:2rem; border-radius:8px; }
+    main { max-width:800px; margin:4rem auto 2rem; padding:2rem; }
     .file-item { margin-bottom:1.5rem; border-bottom:1px solid #ececec; padding-bottom:1rem; }
     .file-item h2 { margin:0 0 .5rem; font-size:1.25rem; }
     .file-item audio { width:100%; margin:.5rem 0; }


### PR DESCRIPTION
## Summary
- make main container transparent on the drop page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686839fbe454832f8eda2dd0a6249f35