### PR TITLE
Add list-proxy API route

### DIFF
--- a/pages/api/list-proxy/[token].js
+++ b/pages/api/list-proxy/[token].js
@@ -1,0 +1,20 @@
+export default async function handler(req, res) {
+  const { token } = req.query;
+  if (!token) {
+    res.status(400).send('Missing token');
+    return;
+  }
+
+  const url = `https://transfer.dannycasio.com/s/${encodeURIComponent(token)}/files?format=xml`;
+
+  try {
+    const upstream = await fetch(url);
+    const body = await upstream.text();
+    res.status(upstream.status)
+       .setHeader('Content-Type', 'application/xml')
+       .send(body);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Proxy error');
+  }
+}

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -61,7 +61,7 @@
     /* ---------- 2. Fetch XML listing via Worker ---------- */
     let xmlStr;
     try {
-      const res = await fetch(`/list-proxy/${token}`);
+      const res = await fetch(`/api/list-proxy/${token}`);
       if (!res.ok) throw new Error(res.status);
       xmlStr = await res.text();
     } catch (e) {


### PR DESCRIPTION
## Summary
- create API route to fetch WebDAV listing
- update drop page to hit new API endpoint

## Testing
- `npx next -v` *(fails: 403 Forbidden)*
- `node` test fetch *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68683d032960832f9a7259ca84cf5c87