### PR TITLE
Fix WebDAV file name extraction

### DIFF
--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -81,7 +81,9 @@
 
     /* ---------- 4. Render each file ---------- */
     responses.forEach(r => {
-      const href = r.getElementsByTagName('*')[0].textContent;   // first <href>
+      const hrefEl = r.querySelector('href');
+      if (!hrefEl) return;
+      const href = hrefEl.textContent;
       const name = decodeURIComponent(href.split('/').filter(Boolean).pop());
       if (!name) return;   // skip empty
 


### PR DESCRIPTION
## Summary
- parse XML responses more robustly in the drop page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68683d05e1bc832f89b3453337837f46