### PR TITLE
Add rewrite for list-proxy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,10 @@ module.exports = {
         source: '/drop/:token',    // any /drop/XYZ
         destination: '/drop/index.html', // serve the static wrapper
       },
+      {
+        source: '/list-proxy/:token',
+        destination: '/api/list-proxy/:token',
+      },
     ];
   },
 };

--- a/pages/api/list-proxy/[token].js
+++ b/pages/api/list-proxy/[token].js
@@ -1,0 +1,20 @@
+export default async function handler(req, res) {
+  const { token } = req.query;
+  if (!token) {
+    res.status(400).send('Missing token');
+    return;
+  }
+
+  const url = `https://transfer.dannycasio.com/s/${encodeURIComponent(token)}/files?format=xml`;
+
+  try {
+    const upstream = await fetch(url);
+    const body = await upstream.text();
+    res.status(upstream.status)
+       .setHeader('Content-Type', 'application/xml')
+       .send(body);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Proxy error');
+  }
+}


### PR DESCRIPTION
## Summary
- proxy /list-proxy/* to new API route
- revert drop page to use original fetch path

## Testing
- `npx next -v` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68683d032960832f9a7259ca84cf5c87