### PR TITLE
Embed snake game on drop page

### DIFF
--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -76,6 +76,11 @@
   }
   .download:hover{ background:var(--btn-dk); }
 
+  /* Snake container should blend into the page */
+  .game-container.no-border{
+    border:none;
+  }
+
   /* footer links */
   footer{
     text-align:center;
@@ -96,6 +101,14 @@
 </head>
 <body>
 
+  <!-- Game Container -->
+  <div class="game-container no-border">
+    <div id="score" class="score-label">Score: 0</div>
+    <div id="high-score" class="score-label">High Score: 0</div>
+    <canvas id="game-canvas" width="800" height="450"></canvas>
+    <div id="pause-overlay" class="pause-overlay"></div>
+  </div>
+
   <div id="drop-content">Loading…</div>
 
   <!---- keep your existing <script> block exactly as-is here ---->
@@ -107,6 +120,9 @@
   </footer>
 </body>
 </html>
+
+<script src="/images-data.js"></script>
+<script src="/game.js" defer></script>
 
 <script>
 (async () => {


### PR DESCRIPTION
## Summary
- embed the snake game on the drop page
- remove the border around the in-page snake canvas
- load game assets on drop page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869175a3c70832f8d6fbe8d8df4cdd3