### PR TITLE
Handle loaded DOM before game start

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -475,6 +475,10 @@ _handleMouseMove(e) {
 
 // Initialize when DOM is ready
 
-window.addEventListener('DOMContentLoaded', () => new GameController());
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', () => new GameController());
+} else {
+  new GameController();
+}
 
 


### PR DESCRIPTION
## Summary
- adjust game initialization to start immediately when the DOM is already loaded

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68691cb2c5c0832fa768c3401f5da58a