### PR TITLE
Fix mobile drop game scroll

### DIFF
--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -257,6 +257,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
     <canvas id="game-canvas" width="800" height="450"></canvas>\
     <div id="pause-overlay" class="pause-overlay"></div>`;
   document.body.insertBefore(container, document.getElementById('drop-content'));
+  container.scrollIntoView({ behavior: 'smooth' });
   await loadScript('/images-data.js');
   await loadScript('/game.js');
   btn.textContent = 'Even more';


### PR DESCRIPTION
## Summary
- ensure drop page scrolls to the newly inserted game container

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686922c07dc0832fa94a0a4b7e843e21