### PR TITLE
Add console timing to drop page and proxy API

### DIFF
--- a/pages/api/list-proxy/[token].js
+++ b/pages/api/list-proxy/[token].js
@@ -8,8 +8,10 @@ export default async function handler(req, res) {
   const url = `https://transfer.dannycasio.com/s/${encodeURIComponent(token)}/files?format=xml`;
 
   try {
+    console.time('api-fetch');
     const upstream = await fetch(url);
     const body = await upstream.text();
+    console.timeEnd('api-fetch');
     res.status(upstream.status)
        .setHeader('Content-Type', 'application/xml')
        .send(body);

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -113,6 +113,7 @@
 
 <script>
 (async () => {
+  console.time('total-load');
   /* 1. token */
   const qs  = new URLSearchParams(location.search);
   let token = qs.get('token') || (location.pathname.match(/^\/drop\/([^/]+)$/)||[])[1];
@@ -137,13 +138,17 @@ function render(name, url, mime='', bytes=0){
   /* 2. fetch XML list */
   let xmlText = '';
   try{
+    console.time('fetch-list');
     const res = await fetch(`/list-proxy/${token}`);
     if(!res.ok) throw new Error(res.status);
     xmlText = await res.text();
-  }catch(e){ box.textContent='Error loading files.'; console.error(e); return; }
+    console.timeEnd('fetch-list');
+  }catch(e){ box.textContent='Error loading files.'; console.error(e); console.timeEnd('total-load'); return; }
 
+  console.time('parse-xml');
   const doc  = new DOMParser().parseFromString(xmlText,'application/xml');
   const all  = [...doc.getElementsByTagName('*')].filter(n=>n.localName==='response');
+  console.timeEnd('parse-xml');
 
   /* 3. normal multi-file share */
   const files = all.filter(r=>{
@@ -224,13 +229,16 @@ const fileURL = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
 
   /* add the assembled section to the page & stop */
   box.appendChild(listWrap);
+  console.timeEnd('total-load');
   return;
 }
 
 
   /* 4. single-file share -> ask head-proxy for filename + mime */
   try{
+    console.time('fetch-head');
     const meta = await fetch(`/head-proxy/${token}`).then(r=>r.json());
+    console.timeEnd('fetch-head');
     const url  = `https://transfer.dannycasio.com/s/${token}/download`;
     if (meta.filename) document.title = meta.filename;
    render(meta.filename || 'file', url, meta.mime, meta.size || 0);
@@ -239,6 +247,7 @@ const fileURL = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
     const url = `https://transfer.dannycasio.com/s/${token}/download`;
   render('file', url);
   }
+  console.timeEnd('total-load');
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- instrument `drop` page with `console.time()` calls for loading and fetch operations
- time the external request in the `list-proxy` API endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686af3e51ff8832f91d95c07f713e3b3