### PR TITLE
Improve Wavesurfer demo playback

### DIFF
--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -45,6 +45,7 @@
     padding:0 1rem;
     display:grid;
     gap:2rem;
+    text-align:center;
   }
 
   /* each item – no white box, just spacing */
@@ -120,7 +121,7 @@
   const qs  = new URLSearchParams(location.search);
   let token = qs.get('token') || (location.pathname.match(/^\/drop\/([^/]+)$/)||[])[1];
   const box = document.getElementById('drop-content');
-  if (!token){ box.textContent = 'No share token provided.'; return; }
+  if (!token){ box.textContent = 'No share token provided.'; box.style.textAlign='center'; return; }
   document.title = 'File Share';
 
   /* helper: build one card */
@@ -145,7 +146,13 @@ function render(name, url, mime='', bytes=0){
     if(!res.ok) throw new Error(res.status);
     xmlText = await res.text();
     console.timeEnd('fetch-list');
-  }catch(e){ box.textContent='Error loading files.'; console.error(e); console.timeEnd('total-load'); return; }
+  }catch(e){
+    box.textContent='Error loading files.';
+    box.style.textAlign='center';
+    console.error(e);
+    console.timeEnd('total-load');
+    return;
+  }
 
   console.time('parse-xml');
   const doc  = new DOMParser().parseFromString(xmlText,'application/xml');

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -288,40 +288,47 @@ document.getElementById('more-btn').addEventListener('click', async e => {
 
 <script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.js"></script>
 <style id="ws-style">
-  .ws-player{position:relative;left:50%;transform:translateX(-50%);max-width:1400px;width:250%;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1);padding:.5rem;margin:.5rem 0}
+  .ws-player{position:relative;max-width:560px;width:100%;margin:.5rem auto;padding:.5rem;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)}
   .ws-wave{height:64px;border-radius:8px;background:#dff2ff}
   .ws-controls{display:flex;align-items:center;gap:.5rem;margin-top:.25rem}
   .ws-btn{background:var(--btn);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer}
   .ws-btn:hover{background:var(--btn-dk)}
   .ws-time{margin-left:auto;font-variant-numeric:tabular-nums}
+  .ws-vol{accent-color:var(--btn);width:80px}
+  @media(max-width:600px){.ws-vol{display:none}}
 </style>
 <script id="ws-init">
 (() => {
   /* --- demo flag guard --- */
   const urlParams = new URLSearchParams(location.search);
-  const isDemo = urlParams.has('demo') && urlParams.get('demo') !== '0';
-  const demoSrc = 'https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3';
+  const isDemo = urlParams.get('demo') === '1';
+  const demoSrc = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3';
 
   const token = urlParams.get('token') || (location.pathname.match(/^\/drop\/([^/]+)/)||[])[1];
 
   if(isDemo && !token){
     const box=document.getElementById('drop-content');
-    box.innerHTML='';
-    box.insertAdjacentHTML('beforeend',`<section class="file-item"><h2>Demo track</h2><audio controls src="${demoSrc}" style="width:100%"></audio><a class="download" href="${demoSrc}" download>Download</a></section>`);
+    if(box && !box.querySelector('audio')){
+      box.innerHTML='';
+      box.insertAdjacentHTML('beforeend',`<section class="file-item"><h2>Demo track</h2><audio controls src="${demoSrc}" style="width:100%"></audio><a class="download" href="${demoSrc}" download>Download</a></section>`);
+    }
   }
 
   document.addEventListener('DOMContentLoaded', () => {
     const box = document.getElementById('drop-content');
+    const players = box ? [...box.querySelectorAll('audio')] : [];
+    if(isDemo) players.forEach(a => {a.src = demoSrc; a.crossOrigin = 'anonymous';});
+
     const handled = new WeakSet();
 
     const init = audio => {
       if (handled.has(audio)) return;
       handled.add(audio);
       if(isDemo && token) audio.src = demoSrc;
+      audio.crossOrigin = 'anonymous';
       try {
         audio.controls=false;
         audio.hidden=true;
-        audio.crossOrigin='anonymous';
 
         const wrap=document.createElement('div');
         wrap.className='ws-player';
@@ -329,7 +336,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
         wave.className='ws-wave';
         const controls=document.createElement('div');
         controls.className='ws-controls';
-        controls.innerHTML=`<button class="ws-btn" aria-label="Pause" type="button">❚❚</button><span class="ws-time">0:00</span>`;
+        controls.innerHTML=`<button class="ws-btn" aria-label="Pause" type="button">❚❚</button><span class="ws-time">0:00</span><input class="ws-vol" type="range" min="0" max="1" step="0.01" value="1">`;
 
         audio.parentNode.insertBefore(wrap,audio);
         wrap.appendChild(wave);
@@ -350,8 +357,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
           barGap:2,
           waveColor:getComputedStyle(document.documentElement).getPropertyValue('--btn')||'#5AB4E5',
           progressColor:getComputedStyle(document.documentElement).getPropertyValue('--btn-dk')||'#3F93C8',
-          backend:'MediaElement',
-          mediaControls:false
+          backend:'MediaElement'
         });
 
         const fmt=t=>{const m=Math.floor(t/60);const s=Math.floor(t%60).toString().padStart(2,'0');return `${m}:${s}`};
@@ -363,7 +369,9 @@ document.getElementById('more-btn').addEventListener('click', async e => {
         ws.on('pause',()=>{btn.textContent=btnPlayIcon;btn.setAttribute('aria-label','Play')});
         ws.on('timeupdate',update);
 
+        const vol=controls.querySelector('.ws-vol');
         btn.addEventListener('click',()=>{ws.isPlaying()?ws.pause():ws.play()});
+        vol.addEventListener('input',()=>ws.setVolume(vol.value));
 
         wrap.tabIndex=0;
         wrap.addEventListener('keydown',e=>{

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -358,17 +358,22 @@ document.getElementById('more-btn').addEventListener('click', async e => {
         const btnPlayIcon='▶';
         const btnPauseIcon='❚❚';
 
-        const ws=WaveSurfer.create({
-          container:wave,
+        const opts = {
+          container: wave,
           media: audio,
-          height:64,
-          barHeight:2,
-          barGap:2,
-          waveColor:getComputedStyle(document.documentElement).getPropertyValue('--btn')||'#5AB4E5',
-          progressColor:getComputedStyle(document.documentElement).getPropertyValue('--btn-dk')||'#3F93C8',
-          backend:'MediaElement',
-          plugins:[WaveSurfer.cursor.create({showTime:true})]
-        });
+          height: 64,
+          barHeight: 2,
+          barGap: 2,
+          waveColor: getComputedStyle(document.documentElement)
+            .getPropertyValue('--btn') || '#5AB4E5',
+          progressColor: getComputedStyle(document.documentElement)
+            .getPropertyValue('--btn-dk') || '#3F93C8',
+          backend: 'MediaElement'
+        };
+        if (WaveSurfer.cursor) {
+          opts.plugins = [WaveSurfer.cursor.create({ showTime: true })];
+        }
+        const ws = WaveSurfer.create(opts);
 
         const fmt=t=>{const m=Math.floor(t/60);const s=Math.floor(t%60).toString().padStart(2,'0');return `${m}:${s}`};
 
@@ -393,6 +398,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
         audio.addEventListener('error',fallback);
       } catch(e){
         audio.controls = true;
+        audio.hidden = false;
       }
     };
 

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -39,7 +39,8 @@
 
   /* list container */
   #drop-content{
-    max-width:900px;
+    max-width:1200px;
+    width:min(100%,90vw);
     margin:3.5rem auto 2.5rem;
     padding:0 1rem;
     display:grid;
@@ -288,14 +289,12 @@ document.getElementById('more-btn').addEventListener('click', async e => {
 
 <script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.min.js"></script>
 <style id="ws-style">
-  .ws-player{position:relative;max-width:560px;width:100%;margin:.5rem auto;padding:.5rem;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)}
+  .ws-player{position:relative;width:min(90vw,1400px);margin:.5rem auto;padding:.5rem;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)}
   .ws-wave{height:64px;border-radius:8px;background:#dff2ff}
   .ws-controls{display:flex;align-items:center;gap:.5rem;margin-top:.25rem}
   .ws-btn{background:var(--btn);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer}
   .ws-btn:hover{background:var(--btn-dk)}
   .ws-time{margin-left:auto;font-variant-numeric:tabular-nums}
-  .ws-vol{accent-color:var(--btn);width:80px}
-  @media(max-width:600px){.ws-vol{display:none}}
 </style>
 <script id="ws-init">
 (() => {
@@ -336,7 +335,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
         wave.className='ws-wave';
         const controls=document.createElement('div');
         controls.className='ws-controls';
-        controls.innerHTML=`<button class="ws-btn" aria-label="Pause" type="button">❚❚</button><span class="ws-time">0:00</span><input class="ws-vol" type="range" min="0" max="1" step="0.01" value="1">`;
+        controls.innerHTML=`<button class="ws-btn" aria-label="Pause" type="button">❚❚</button><span class="ws-time">0:00</span>`;
 
         audio.parentNode.insertBefore(wrap,audio);
         wrap.appendChild(wave);
@@ -357,7 +356,8 @@ document.getElementById('more-btn').addEventListener('click', async e => {
           barGap:2,
           waveColor:getComputedStyle(document.documentElement).getPropertyValue('--btn')||'#5AB4E5',
           progressColor:getComputedStyle(document.documentElement).getPropertyValue('--btn-dk')||'#3F93C8',
-          backend:'MediaElement'
+          backend:'MediaElement',
+          plugins:[WaveSurfer.cursor.create({showTime:true})]
         });
 
         const fmt=t=>{const m=Math.floor(t/60);const s=Math.floor(t%60).toString().padStart(2,'0');return `${m}:${s}`};
@@ -369,9 +369,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
         ws.on('pause',()=>{btn.textContent=btnPlayIcon;btn.setAttribute('aria-label','Play')});
         ws.on('timeupdate',update);
 
-        const vol=controls.querySelector('.ws-vol');
         btn.addEventListener('click',()=>{ws.isPlaying()?ws.pause():ws.play()});
-        vol.addEventListener('input',()=>ws.setVolume(vol.value));
 
         wrap.tabIndex=0;
         wrap.addEventListener('keydown',e=>{

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -66,7 +66,8 @@
   /* full-width download button */
   .download{
     display:block;
-    width:100%;
+    width:calc(100% + 2rem); /* match footer width */
+    margin:0 -1rem;
     text-align:center;
     background:var(--btn);
     color:#fff;
@@ -324,7 +325,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
   document.addEventListener('DOMContentLoaded', () => {
     const box = document.getElementById('drop-content');
     const players = box ? [...box.querySelectorAll('audio')] : [];
-    if(isDemo) players.forEach(a => {a.crossOrigin='anonymous'; a.src=demoSrc;});
+    if(isDemo) players.forEach(a => {a.crossOrigin='anonymous'; a.src=demoSrc; a.load();});
 
     const handled = new WeakSet();
 
@@ -333,6 +334,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
       handled.add(audio);
       audio.crossOrigin = 'anonymous';
       if(isDemo && token) audio.src = demoSrc;
+      audio.load();
       try {
         audio.controls=false;
         audio.hidden=true;
@@ -386,7 +388,9 @@ document.getElementById('more-btn').addEventListener('click', async e => {
           else if(e.code==='ArrowLeft'){ws.seekTo(Math.max(0,(ws.getCurrentTime()-5)/ws.getDuration()));}
         });
 
-        ws.on('error',()=>{audio.controls=true;audio.hidden=false;wrap.replaceWith(audio)});
+        const fallback=()=>{audio.controls=true;audio.hidden=false;if(wrap.parentNode)wrap.replaceWith(audio)};
+        ws.on('error',fallback);
+        audio.addEventListener('error',fallback);
       } catch(e){
         audio.controls = true;
       }

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -63,26 +63,21 @@
     border-radius:8px;
   }
 
-  /* full-width download button */
+  /* centered download button similar width as footer links */
   .download{
     display:block;
-    width:calc(100% + 2rem); /* match footer width */
-    margin:0 -1rem;
+    width:max-content;
+    margin:0 auto;
     text-align:center;
     background:var(--btn);
     color:#fff;
     text-decoration:none;
-    padding:.65rem 0;
+    padding:.65rem 1.2rem;
     border-radius:10px;
     font-weight:600;
     transition:background .15s ease;
   }
   .download:hover{ background:var(--btn-dk); }
-
-  /* Snake container should blend into the page */
-  .game-container.no-border{
-    border:none;
-  }
 
   /* footer links */
   footer{
@@ -109,7 +104,7 @@
     <ul class="contacts">
       <li><a href="mailto:dannycasio@me.com">Email</a></li>
       <li><a href="https://instagram.com/dannycasio_" target="_blank" rel="noopener">Instagram</a></li>
-      <li><a id="more-btn" href="#">More</a></li>
+      <li><a href="/more.html">More</a></li>
     </ul>
   </footer>
 
@@ -264,37 +259,6 @@ const fileURL = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
 
 
 
-<script>
-function loadScript(src){
-  return new Promise((res, rej) => {
-    const s = document.createElement('script');
-    s.src = src;
-    s.onload = res;
-    s.onerror = rej;
-    document.body.appendChild(s);
-  });
-}
-
-document.getElementById('more-btn').addEventListener('click', async e => {
-  const btn = e.currentTarget;
-  if (btn.dataset.loaded) return;
-  e.preventDefault();
-  const container = document.createElement('div');
-  container.className = 'game-container no-border';
-  container.innerHTML = `\
-    <div id="score" class="score-label">Score: 0</div>\
-    <div id="high-score" class="score-label">High Score: 0</div>\
-    <canvas id="game-canvas" width="800" height="450"></canvas>\
-    <div id="pause-overlay" class="pause-overlay"></div>`;
-  document.body.insertBefore(container, document.getElementById('drop-content'));
-  container.scrollIntoView({ behavior: 'smooth' });
-  await loadScript('/images-data.js');
-  await loadScript('/game.js');
-  btn.textContent = 'Even more';
-  btn.href = '/more.html';
-  btn.dataset.loaded = '1';
-});
-</script>
 
 <script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.min.js"></script>
 <style id="ws-style">

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -286,7 +286,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
 });
 </script>
 
-<script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.min.js"></script>
 <style id="ws-style">
   .ws-player{position:relative;max-width:560px;width:100%;margin:.5rem auto;padding:.5rem;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)}
   .ws-wave{height:64px;border-radius:8px;background:#dff2ff}
@@ -302,7 +302,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
   /* --- demo flag guard --- */
   const urlParams = new URLSearchParams(location.search);
   const isDemo = urlParams.get('demo') === '1';
-  const demoSrc = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3';
+  const demoSrc = 'https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3';
 
   const token = urlParams.get('token') || (location.pathname.match(/^\/drop\/([^/]+)/)||[])[1];
 

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -249,7 +249,10 @@ const fileURL = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
   }
   console.timeEnd('total-load');
 })();
-</script>
+  </script>
+
+
+
 
 <script>
 function loadScript(src){
@@ -281,6 +284,111 @@ document.getElementById('more-btn').addEventListener('click', async e => {
   btn.href = '/more.html';
   btn.dataset.loaded = '1';
 });
+</script>
+
+<script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.js"></script>
+<style id="ws-style">
+  .ws-player{position:relative;left:50%;transform:translateX(-50%);max-width:1400px;width:250%;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1);padding:.5rem;margin:.5rem 0}
+  .ws-wave{height:64px;border-radius:8px;background:#dff2ff}
+  .ws-controls{display:flex;align-items:center;gap:.5rem;margin-top:.25rem}
+  .ws-btn{background:var(--btn);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer}
+  .ws-btn:hover{background:var(--btn-dk)}
+  .ws-time{margin-left:auto;font-variant-numeric:tabular-nums}
+</style>
+<script id="ws-init">
+(() => {
+  /* --- demo flag guard --- */
+  const urlParams = new URLSearchParams(location.search);
+  const isDemo = urlParams.has('demo') && urlParams.get('demo') !== '0';
+  const demoSrc = 'https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3';
+
+  const token = urlParams.get('token') || (location.pathname.match(/^\/drop\/([^/]+)/)||[])[1];
+
+  if(isDemo && !token){
+    const box=document.getElementById('drop-content');
+    box.innerHTML='';
+    box.insertAdjacentHTML('beforeend',`<section class="file-item"><h2>Demo track</h2><audio controls src="${demoSrc}" style="width:100%"></audio><a class="download" href="${demoSrc}" download>Download</a></section>`);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const box = document.getElementById('drop-content');
+    const handled = new WeakSet();
+
+    const init = audio => {
+      if (handled.has(audio)) return;
+      handled.add(audio);
+      if(isDemo && token) audio.src = demoSrc;
+      try {
+        audio.controls=false;
+        audio.hidden=true;
+        audio.crossOrigin='anonymous';
+
+        const wrap=document.createElement('div');
+        wrap.className='ws-player';
+        const wave=document.createElement('div');
+        wave.className='ws-wave';
+        const controls=document.createElement('div');
+        controls.className='ws-controls';
+        controls.innerHTML=`<button class="ws-btn" aria-label="Pause" type="button">❚❚</button><span class="ws-time">0:00</span>`;
+
+        audio.parentNode.insertBefore(wrap,audio);
+        wrap.appendChild(wave);
+        wrap.appendChild(controls);
+        wrap.appendChild(audio);
+
+        const btn=controls.querySelector('.ws-btn');
+        const time=controls.querySelector('.ws-time');
+
+        const btnPlayIcon='▶';
+        const btnPauseIcon='❚❚';
+
+        const ws=WaveSurfer.create({
+          container:wave,
+          media: audio,
+          height:64,
+          barHeight:2,
+          barGap:2,
+          waveColor:getComputedStyle(document.documentElement).getPropertyValue('--btn')||'#5AB4E5',
+          progressColor:getComputedStyle(document.documentElement).getPropertyValue('--btn-dk')||'#3F93C8',
+          backend:'MediaElement',
+          mediaControls:false
+        });
+
+        const fmt=t=>{const m=Math.floor(t/60);const s=Math.floor(t%60).toString().padStart(2,'0');return `${m}:${s}`};
+
+        const update=()=>{time.textContent=fmt(ws.getCurrentTime())};
+
+        ws.once('ready',()=>{ws.play();});
+        ws.on('play',()=>{btn.textContent=btnPauseIcon;btn.setAttribute('aria-label','Pause')});
+        ws.on('pause',()=>{btn.textContent=btnPlayIcon;btn.setAttribute('aria-label','Play')});
+        ws.on('timeupdate',update);
+
+        btn.addEventListener('click',()=>{ws.isPlaying()?ws.pause():ws.play()});
+
+        wrap.tabIndex=0;
+        wrap.addEventListener('keydown',e=>{
+          if(e.code==='Space'){e.preventDefault();btn.click();}
+          else if(e.code==='ArrowRight'){ws.seekTo(Math.min(1,(ws.getCurrentTime()+5)/ws.getDuration()));}
+          else if(e.code==='ArrowLeft'){ws.seekTo(Math.max(0,(ws.getCurrentTime()-5)/ws.getDuration()));}
+        });
+
+        ws.on('error',()=>{audio.controls=true;audio.hidden=false;wrap.replaceWith(audio)});
+      } catch(e){
+        audio.controls = true;
+      }
+    };
+
+    [...box.querySelectorAll('audio')].forEach(init);
+
+    const obs = new MutationObserver(muts => {
+      muts.forEach(m => m.addedNodes.forEach(n => {
+        if(n.tagName==='AUDIO') init(n);
+        else if(n.querySelectorAll) n.querySelectorAll('audio').forEach(init);
+      }));
+    });
+    obs.observe(box,{childList:true,subtree:true});
+  });
+})();
 </script>
 
 

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -53,6 +53,7 @@
     font-size:1.15rem;
     font-weight:600;
     word-break:break-all;
+    text-align:center;
   }
   .file-item audio{
     width:100%;
@@ -289,7 +290,7 @@ document.getElementById('more-btn').addEventListener('click', async e => {
 
 <script src="https://unpkg.com/wavesurfer.js@7.9.9/dist/wavesurfer.min.js"></script>
 <style id="ws-style">
-  .ws-player{position:relative;width:min(90vw,1400px);margin:.5rem auto;padding:.5rem;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)}
+  .ws-player{position:relative;width:min(80vw,1000px);margin:.5rem auto;padding:.5rem;font-family:system-ui,sans-serif;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)}
   .ws-wave{height:64px;border-radius:8px;background:#dff2ff}
   .ws-controls{display:flex;align-items:center;gap:.5rem;margin-top:.25rem}
   .ws-btn{background:var(--btn);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer}
@@ -309,22 +310,22 @@ document.getElementById('more-btn').addEventListener('click', async e => {
     const box=document.getElementById('drop-content');
     if(box && !box.querySelector('audio')){
       box.innerHTML='';
-      box.insertAdjacentHTML('beforeend',`<section class="file-item"><h2>Demo track</h2><audio controls src="${demoSrc}" style="width:100%"></audio><a class="download" href="${demoSrc}" download>Download</a></section>`);
+      box.insertAdjacentHTML('beforeend',`<section class="file-item"><h2>Demo track</h2><audio controls crossOrigin="anonymous" src="${demoSrc}" style="width:100%"></audio><a class="download" href="${demoSrc}" download>Download</a></section>`);
     }
   }
 
   document.addEventListener('DOMContentLoaded', () => {
     const box = document.getElementById('drop-content');
     const players = box ? [...box.querySelectorAll('audio')] : [];
-    if(isDemo) players.forEach(a => {a.src = demoSrc; a.crossOrigin = 'anonymous';});
+    if(isDemo) players.forEach(a => {a.crossOrigin='anonymous'; a.src=demoSrc;});
 
     const handled = new WeakSet();
 
     const init = audio => {
       if (handled.has(audio)) return;
       handled.add(audio);
-      if(isDemo && token) audio.src = demoSrc;
       audio.crossOrigin = 'anonymous';
+      if(isDemo && token) audio.src = demoSrc;
       try {
         audio.controls=false;
         audio.hidden=true;


### PR DESCRIPTION
## Summary
- allow cross-origin requests for demo track
- reuse native audio element in Wavesurfer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ba5003364832f89f735acc2564d80