### PR TITLE
Restore share-proxy for audio previews

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,10 @@ module.exports = {
         source: '/list-proxy/:token',
         destination: '/api/list-proxy/:token',
       },
+      {
+        source: '/share-proxy/:token',
+        destination: '/api/share-proxy/:token',
+      },
     ];
   },
 };

--- a/pages/api/share-proxy/[token].js
+++ b/pages/api/share-proxy/[token].js
@@ -1,0 +1,32 @@
+import { Readable } from 'stream';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
+
+export default async function handler(req, res) {
+  const { token } = req.query;
+  const file = req.query.file;
+  if (!token || !file) {
+    res.status(400).send('Missing token or file');
+    return;
+  }
+
+  const range = req.headers['range'];
+  const url = `https://transfer.dannycasio.com/s/${encodeURIComponent(token)}/download?path=%2F&files=${encodeURIComponent(file)}`;
+  const headers = range ? { Range: range } : {};
+  const upstream = await fetch(url, { headers });
+
+  res.status(upstream.status);
+  ['content-type', 'content-length', 'accept-ranges'].forEach(h => {
+    const val = upstream.headers.get(h);
+    if (val) res.setHeader(h, val);
+  });
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+
+  const pump = promisify(pipeline);
+  await pump(Readable.fromWeb(upstream.body), res);
+}

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -121,13 +121,13 @@
   document.title = 'File Share';
 
   /* helper: build one card */
-function render(name, url, mime='', bytes=0){
+  function render(name, url, mime='', bytes=0){
   const wrap = document.createElement('section');
   wrap.className = 'file-item';
   wrap.innerHTML =
     `<h2>${name}</h2>` +
     (/^audio\//.test(mime) || /\.(mp3|wav|ogg)$/i.test(name)
-       ? `<audio controls style="width:100%" src="${url}"></audio>` : '') +
+       ? `<audio controls crossorigin="anonymous" style="width:100%" src="${url}"></audio>` : '') +
     `<a class="download" href="${url}" download>Download</a>` +
     (bytes ? `<div style="font-size:.9rem;margin-top:.4rem">Size: ${(bytes/(1024*1024)).toFixed(1)} MB</div>` : '');
   box.appendChild(wrap);
@@ -185,7 +185,7 @@ if (files.length) {
   /* filename + direct download URL */
   const href = r.getElementsByTagNameNS('*','href')[0].textContent;
   const name = decodeURIComponent(href.split('/').filter(Boolean).pop());
-const fileURL = `https://transfer.dannycasio.com/s/${token}/download?path=/${encodeURIComponent(name)}`;
+  const fileURL = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
 
   /* <li> item */
   const li = document.createElement('li');
@@ -196,6 +196,7 @@ const fileURL = `https://transfer.dannycasio.com/s/${token}/download?path=/${enc
     const player = document.createElement('audio');
     player.controls = true;
     player.setAttribute('controls', '');
+    player.crossOrigin = 'anonymous';
     player.src = fileURL;
     player.onerror = () => player.style.display = 'none';
     player.style.display = 'block';
@@ -244,12 +245,13 @@ const fileURL = `https://transfer.dannycasio.com/s/${token}/download?path=/${enc
     console.time('fetch-head');
     const meta = await fetch(`/head-proxy/${token}`).then(r=>r.json());
     console.timeEnd('fetch-head');
-    const url  = `https://transfer.dannycasio.com/s/${token}/download`;
+    const name = meta.filename || 'file';
+    const url  = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
     if (meta.filename) document.title = meta.filename;
-   render(meta.filename || 'file', url, meta.mime, meta.size || 0);
+   render(name, url, meta.mime, meta.size || 0);
   }catch(err){
     /* fallback: still show a basic link */
-    const url = `https://transfer.dannycasio.com/s/${token}/download`;
+    const url = `/share-proxy/${token}?file=file`;
   render('file', url);
   }
   console.timeEnd('total-load');
@@ -332,7 +334,8 @@ const fileURL = `https://transfer.dannycasio.com/s/${token}/download?path=/${enc
             .getPropertyValue('--btn') || '#5AB4E5',
           progressColor: getComputedStyle(document.documentElement)
             .getPropertyValue('--btn-dk') || '#3F93C8',
-          backend: 'MediaElement'
+          backend: 'MediaElement',
+          xhr: { mode: 'cors' }
         };
         if (WaveSurfer.cursor) {
           opts.plugins = [WaveSurfer.cursor.create({ showTime: true })];


### PR DESCRIPTION
## Summary
- create `/share-proxy/:token` API route streaming files from Nextcloud
- expose the new route via a rewrite
- update the drop page to load audio through the proxy and fix WaveSurfer init

## Testing
- `npm run lint && npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c3a1901c8832fa82beb2d84689751