### PR TITLE
Add dynamic drop page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,10 +4,6 @@ module.exports = {
   async rewrites() {
     return [
       {
-        source: '/drop/:token',    // any /drop/XYZ
-        destination: '/drop/index.html', // serve the static wrapper
-      },
-      {
         source: '/list-proxy/:token',
         destination: '/api/list-proxy/:token',
       },

--- a/pages/drop/[token].js
+++ b/pages/drop/[token].js
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+
+export async function getServerSideProps({ params, res }) {
+  const token = params.token || '';
+  let title = 'File Share';
+
+  try {
+    const url = `https://transfer.dannycasio.com/s/${encodeURIComponent(token)}/files?format=xml`;
+    const upstream = await fetch(url);
+    const xml = await upstream.text();
+    const matches = [...xml.matchAll(/<[^>]*href[^>]*>([^<]+)<\/[^>]*href>/g)].map(m => m[1]);
+    const files = matches.filter(h => !h.endsWith('/webdav/') && !h.endsWith('/'));
+    if (files.length === 1) {
+      const name = decodeURIComponent(files[0].split('/').filter(Boolean).pop());
+      title = name;
+    }
+  } catch (err) {
+    console.error(err);
+  }
+
+  const filePath = path.join(process.cwd(), 'public/drop/index.html');
+  let html = fs.readFileSync(filePath, 'utf8');
+  html = html.replace('<title>File Share</title>', `<title>${title}</title>\n<meta property="og:title" content="${title}">`);
+
+  res.setHeader('Content-Type', 'text/html');
+  res.write(html);
+  res.end();
+
+  return { props: {} };
+}
+
+export default function DropToken() { return null; }


### PR DESCRIPTION
## Summary
- add `pages/drop/[token].js` dynamic server-side page
- remove rewrite for `/drop/:token` so the new page serves those URLs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870191cfc24832f891927ad2b2481d8