### PR TITLE
Handle proxy errors in share-proxy

### DIFF
--- a/pages/api/share-proxy/[token].js
+++ b/pages/api/share-proxy/[token].js
@@ -13,20 +13,33 @@ export default async function handler(req, res) {
   const range = req.headers['range'];
   const url = `https://transfer.dannycasio.com/s/${encodeURIComponent(token)}/download?path=%2F&files=${encodeURIComponent(file)}`;
   const headers = range ? { Range: range } : {};
-  const upstream = await fetch(url, { headers });
-
-  res.status(upstream.status);
-  ['content-type', 'content-length', 'accept-ranges'].forEach(h => {
-    const val = upstream.headers.get(h);
-    if (val) res.setHeader(h, val);
-  });
-  res.setHeader('Access-Control-Allow-Origin', '*');
-
-  if (!upstream.body) {
-    res.end();
-    return;
-  }
 
   const pump = promisify(pipeline);
-  await pump(Readable.fromWeb(upstream.body), res);
+  try {
+    const upstream = await fetch(url, { headers });
+
+    res.status(upstream.status);
+    ['content-type', 'content-length', 'accept-ranges'].forEach(h => {
+      const val = upstream.headers.get(h);
+      if (val) res.setHeader(h, val);
+    });
+    res.setHeader('Access-Control-Allow-Origin', '*');
+
+    if (!upstream.body) {
+      res.end();
+      return;
+    }
+
+    await pump(Readable.fromWeb(upstream.body), res).catch(err => {
+      res.destroy();
+      throw err;
+    });
+  } catch (err) {
+    console.error('Proxy error:', err);
+    if (!res.headersSent) {
+      res.status(502).send('Proxy error');
+    } else {
+      res.end();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add robust error handling to share-proxy endpoint

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e5f53b24832fbf00c7f9a34f98a7