### PR TITLE
Validate token and file query parameters

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,0 +1,10 @@
+export const TOKEN_PATTERN = /^[A-Za-z0-9]{1,64}$/;
+export const FILE_PATTERN = /^[A-Za-z0-9._-]{1,256}$/;
+
+export function isValidToken(token) {
+  return typeof token === 'string' && TOKEN_PATTERN.test(token);
+}
+
+export function isValidFile(file) {
+  return typeof file === 'string' && FILE_PATTERN.test(file);
+}

--- a/pages/api/list-proxy/[token].js
+++ b/pages/api/list-proxy/[token].js
@@ -1,7 +1,14 @@
+import { isValidToken } from '../../../lib/validation';
+
 export default async function handler(req, res) {
   const { token } = req.query;
   if (!token) {
     res.status(400).send('Missing token');
+    return;
+  }
+
+  if (!isValidToken(token)) {
+    res.status(400).send('Invalid token');
     return;
   }
 

--- a/pages/api/share-proxy/[token].js
+++ b/pages/api/share-proxy/[token].js
@@ -1,12 +1,23 @@
 import { Readable } from 'stream';
 import { pipeline } from 'stream';
 import { promisify } from 'util';
+import { isValidToken, isValidFile } from '../../../lib/validation';
 
 export default async function handler(req, res) {
   const { token } = req.query;
   const file = req.query.file;
   if (!token || !file) {
     res.status(400).send('Missing token or file');
+    return;
+  }
+
+  if (!isValidToken(token)) {
+    res.status(400).send('Invalid token');
+    return;
+  }
+
+  if (!isValidFile(file)) {
+    res.status(400).send('Invalid file');
     return;
   }
 


### PR DESCRIPTION
## Summary
- Define reusable token and file validation helpers
- Validate query parameters in list-proxy and share-proxy routes
- Return 400 responses for invalid token or file

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e60ef794832fa070cbfbcd8b1554