### PR TITLE
feat: async file read and xml2js parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "artwork-snake",
+  "version": "1.0.0",
+  "description": "A small snake game that uses images for the snake body. Open `index.html` in your browser to play.",
+  "main": "next.config.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "xml2js": "^0.6.2"
+  }
+}


### PR DESCRIPTION
## Summary
- switch drop token page to async fs.promises.readFile
- parse file list with xml2js instead of regex
- add xml2js dependency

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6895e6002e54832f9a8ad1c9abebb0dc