### PR TITLE
Fix single-file share titles and Open Graph metadata

### DIFF
--- a/pages/drop/[token].js
+++ b/pages/drop/[token].js
@@ -17,8 +17,10 @@ export async function getServerSideProps({ params, res }) {
     const responses = Array.isArray(parsed.multistatus?.response)
       ? parsed.multistatus.response
       : [parsed.multistatus?.response].filter(Boolean);
-    const hrefs = responses.map(r => r.href).filter(Boolean);
-    const files = hrefs.filter(h => !h.endsWith('/webdav/') && !h.endsWith('/'));
+    const files = responses
+      .filter(r => !('collection' in (r.propstat?.prop?.resourcetype || {})))
+      .map(r => r.href)
+      .filter(Boolean);
     if (files.length === 1) {
       const name = decodeURIComponent(files[0].split('/').filter(Boolean).pop());
       title = name;

--- a/public/drop/index.html
+++ b/public/drop/index.html
@@ -116,7 +116,6 @@
   let token = qs.get('token') || (location.pathname.match(/^\/drop\/([^/]+)$/)||[])[1];
   const box = document.getElementById('drop-content');
   if (!token){ box.textContent = 'No share token provided.'; box.style.textAlign='center'; return; }
-  document.title = 'File Share';
 
   /* make a card */
   function render(name, url, mime='', bytes=0){
@@ -154,15 +153,16 @@
   console.timeEnd('parse-xml');
 
   /* filter files */
-  const files = all.filter(r=>{
-    const href = r.getElementsByTagNameNS('*','href')[0]?.textContent || '';
-    return !href.endsWith('/webdav/') && !href.endsWith('/');
-  });
+  const files = all.filter(r =>
+    !r.getElementsByTagNameNS('*', 'collection').length
+  );
 
   if (files.length === 1) {
     const href = files[0].getElementsByTagNameNS('*','href')[0].textContent;
     const name = decodeURIComponent(href.split('/').filter(Boolean).pop());
     document.title = name;
+    const og = document.querySelector('meta[property="og:title"]');
+    if (og) og.setAttribute('content', name);
   }
 
   box.innerHTML = '';
@@ -245,8 +245,12 @@ if (files.length) {
     console.timeEnd('fetch-head');
     const name = meta.filename || 'file';
     const url  = `/share-proxy/${token}?file=${encodeURIComponent(name)}`;
-    if (meta.filename) document.title = meta.filename;
-   render(name, url, meta.mime, meta.size || 0);
+    if (meta.filename) {
+      document.title = meta.filename;
+      const og = document.querySelector('meta[property="og:title"]');
+      if (og) og.setAttribute('content', meta.filename);
+    }
+    render(name, url, meta.mime, meta.size || 0);
   }catch(err){
     /* basic link fallback */
     const url = `/share-proxy/${token}?file=file`;


### PR DESCRIPTION
## Summary
- Filter directory entries on server by checking for `resourcetype.collection`, so single-file shares pick up the actual file name
- Keep client-side title and `og:title` meta tag in sync for accurate previews

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8399654832fbf6339dc37e85799